### PR TITLE
Add digitaloceanspaces.com to Exempt CDN list so Download link works.

### DIFF
--- a/video-embed-thumbnail-generator.php
+++ b/video-embed-thumbnail-generator.php
@@ -2479,6 +2479,7 @@ function kgvid_single_video_code($query_atts, $atts, $content, $post_id) {
 			$attachment_url = wp_get_attachment_url($id);
 			if ( $attachment_url == false ) { _e("Invalid video ID", 'video-embed-thumbnail-generator'); continue; }
 			$exempt_cdns = array(
+				'digitaloceanspaces.com',
 				'amazonaws.com',
 				'rackspace.com',
 				'netdna-cdn.com',


### PR DESCRIPTION
I'm using the Download Log plugin, and need the Download link to track CDN downloads. We're using Digital Ocean Spaces right now, so I added it to the exempt check.

It'd be great if this was a text-area on the options page to paste in other domains that should be considered exempt.